### PR TITLE
ENG-9: Keyword flagging for critical medical terms

### DIFF
--- a/backend/alembic/versions/7140bd44c92c_add_flags_to_documents.py
+++ b/backend/alembic/versions/7140bd44c92c_add_flags_to_documents.py
@@ -1,0 +1,32 @@
+"""add flags to documents
+
+Revision ID: 7140bd44c92c
+Revises: 9772f58b4cd4
+Create Date: 2026-04-25 22:11:37.806660
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '7140bd44c92c'
+down_revision: Union[str, Sequence[str], None] = '9772f58b4cd4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('chat_messages', sa.Column('sources', sa.JSON(), nullable=True))
+    op.add_column('documents', sa.Column('flags', sa.JSON(), nullable=True))
+    op.drop_column('documents', 'flagged_keywords')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column('documents', sa.Column('flagged_keywords', postgresql.JSON(astext_type=sa.Text()), autoincrement=False, nullable=True))
+    op.drop_column('documents', 'flags')
+    op.drop_column('chat_messages', 'sources')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, Nullable, String, Text, null
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -13,7 +13,7 @@ class Document(Base):
     filename: Mapped[str] = mapped_column(String, nullable=False)
     original_text: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String, default="pending")
-    flagged_keywords: Mapped[list] = mapped_column(JSON, default=list)
+    flags: Mapped[list] = mapped_column(JSON, default=list, nullable=True)
     user_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id"), nullable=False
     )

--- a/backend/app/routes/documents.py
+++ b/backend/app/routes/documents.py
@@ -10,6 +10,7 @@ from app.services.document_processor import (
     embed_and_store,
     extract_text_from_pdf,
 )
+from app.services.keyword_service import check_keyword
 
 router = APIRouter(prefix="/documents", tags=["documents"])
 
@@ -21,12 +22,20 @@ async def upload_document(
     current_user: User = Depends(get_current_user),
 ):
     file_bytes = await file.read()
-    text = extract_text_from_pdf(file_bytes=file_bytes)
+    text_list = extract_text_from_pdf(file_bytes=file_bytes)
+
+    text = " ".join([item["text"] for item in text_list])
+
+    all_flags = []
+    for item in text_list:
+      all_flags += check_keyword(text=item["text"], page_number=item["page_number"])
+
     chunks = chunk_text(text=text)
     document = Document(
         filename=file.filename,
         original_text=text,
         user_id=current_user.id,
+        flags=all_flags,
         status="processing",
     )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -30,6 +30,7 @@ class DocumentResponse(BaseModel):
     filename: str
     status: str
     user_id: int
+    flags: list[dict]
     created_at: datetime
 
 

--- a/backend/app/services/document_processor.py
+++ b/backend/app/services/document_processor.py
@@ -17,15 +17,12 @@ pinecone_client = Pinecone(api_key=PINECONE_API_KEY)
 pinecone_index = pinecone_client.Index("meddocs")
 
 
-def extract_text_from_pdf(file_bytes: bytes) -> str:
-    doc = fitz.open(stream=file_bytes, filetype="pdf")
-    text = ""
-
-    for page in doc:
-        text += str(page.get_text("text"))
+def extract_text_from_pdf(file_bytes: bytes) -> list[dict]:
+    doc = fitz.open(stream=file_bytes, filetype="pdf" )
+    text_and_pages_number = [{"text": page.get_text("text"), "page_number": index + 1} for index, page in enumerate(doc) ] # type: ignore
     doc.close()
 
-    return text.strip()
+    return text_and_pages_number
 
 
 def chunk_text(text: str) -> list[str]:

--- a/backend/app/services/keyword_service.py
+++ b/backend/app/services/keyword_service.py
@@ -1,0 +1,3 @@
+def check_keyword(text: str, page_number: int) -> list[dict]:
+    keywords = ["kritisch", "dringend", "abnormal", "notfall", "sofort"]
+    return [{"keyword": kw, "page_number": page_number} for kw in keywords if kw in text.lower()]


### PR DESCRIPTION
## Summary
- Added `keyword_service.py` that scans document text for critical German medical terms (kritisch, dringend, abnormal, notfall, sofort)
- Refactored `extract_text_from_pdf` to return per-page text with page numbers, enabling keyword-to-page mapping
- Stored flags as JSON in the `documents` table, populated at upload time
- Exposed flags via `GET /documents/{id}` response

## Test plan
- [ ] Upload a PDF containing critical keywords
- [ ] Verify `GET /documents/{id}` returns `flags` array with correct keywords and page numbers
- [ ] Upload a PDF with no keywords — verify `flags` is an empty list
