### PR TITLE
docs(adr): ADR-001..005 — architecture decision records (ENG-16)

### DIFF
--- a/docs/adr/ADR-001-monolith.md
+++ b/docs/adr/ADR-001-monolith.md
@@ -1,0 +1,32 @@
+# ADR-001 — A modular monolith, not microservices
+
+**Status:** Accepted · M1
+
+## Context
+MedDocs is built by **one developer**, shipping to a moderate number of clinics. The modules
+(`auth, orgs, documents, workflow, ai, flags, audit, notifications, analytics`) need clear internal
+boundaries, but a workflow transition routinely touches several of them **inside one database
+transaction** (update `documents`, write `document_events`, enqueue a `notification`) — and it must be
+atomic.
+
+## Decision
+One **modular monolith**: a single FastAPI application, internally split into modules, plus (from M6) one
+background worker, talking to one PostgreSQL. Deploy is one unit.
+
+## Alternatives considered
+- **Microservices (a service per module).** Rejected: microservices solve an **organisational/independent-
+  scaling** problem — many teams, parts that scale very differently. We have neither. The cost is real and
+  immediate: network calls between modules, **distributed transactions** (a workflow transition would span
+  services), separate deploys, and observability overhead — all to solve a problem we don't have.
+- **Serverless functions.** Rejected: cold starts and awkward long-lived connections (DB pools,
+  WebSockets); splinters the transactional workflow.
+
+## Consequences
+**Good:** atomic multi-module transactions for free; one thing to deploy, debug, and reason about;
+module boundaries can be refactored cheaply because they're just Python packages, not network contracts.
+**Bad:** the whole app scales as one unit (fine at this scale); internal module discipline is on us —
+nothing *physically* stops a cross-module shortcut, so boundaries need code review to stay honest.
+
+## Revisit when
+A module needs to scale independently, or separate teams own separate parts, **and** we've measured the
+monolith as the actual bottleneck. Extract that one module then — not preemptively.

--- a/docs/adr/ADR-002-multi-tenancy.md
+++ b/docs/adr/ADR-002-multi-tenancy.md
@@ -1,0 +1,36 @@
+# ADR-002 — Multi-tenancy: shared DB, `organization_id` on every row
+
+**Status:** Accepted · M1
+
+## Context
+Multiple clinics share one deployment. Their data must be **hard-isolated** (a DSGVO requirement — Clinic A
+must never see Clinic B's patients), while a solo operator keeps the ops burden low. IDs appear in URLs.
+
+## Decision
+- **One shared database, one shared schema.** Every tenant-owned table carries a **`NOT NULL
+  organization_id`** column (`erd.md`) — the one exception is `users` (a global identity linked to orgs via
+  `memberships`).
+- Isolation is a **uniform filter** `WHERE organization_id = <caller's org>`, applied through a **base
+  query helper** so it can't be forgotten per-endpoint. The caller's org comes from the JWT/membership,
+  never from the URL.
+- **Primary keys are `uuid`** (`gen_random_uuid()`) — non-enumerable, so URL IDs don't leak record count or
+  identity. Obscurity is *not* the isolation mechanism; `organization_id` is.
+- **Postgres Row-Level Security (RLS)** is the **strong form**: the database itself refuses other tenants'
+  rows even if the app forgets the filter. Adopted as the belt-and-braces layer.
+
+## Alternatives considered
+- **Database-per-tenant.** Strongest isolation, but N databases to migrate/back up/monitor — ops cost that
+  doesn't fit a solo team, and cross-tenant analytics become painful. Rejected at this scale.
+- **Schema-per-tenant.** Middle ground; still multiplies migration surface by tenant count. Rejected.
+- **Shared rows with only an app-level filter, no RLS.** One forgotten `WHERE` = a cross-tenant breach.
+  Rejected as the *sole* mechanism — hence RLS underneath.
+
+## Consequences
+**Good:** one migration, one backup, cheap to run; trivial cross-tenant admin analytics; the uniform filter
++ RLS makes isolation **structural**, not per-endpoint discipline.
+**Bad:** "noisy neighbour" — one tenant's load touches shared tables (mitigate with indexes/limits); a
+single logical DB is a single blast radius (mitigate with RLS + backups).
+
+## Revisit when
+A tenant contractually demands physical isolation, or one tenant's scale/noise justifies its own database —
+then peel *that* tenant out, keeping shared-rows for the rest.

--- a/docs/adr/ADR-003-auth.md
+++ b/docs/adr/ADR-003-auth.md
@@ -1,0 +1,44 @@
+# ADR-003 — Authentication (stateless JWT) + Authorization (RBAC read from the DB)
+
+**Status:** Accepted · M1
+
+> **Two mechanisms, one ADR — kept explicitly separate** (`permissions.md` §1). **AuthN** = *are you who you
+> say you are?* **AuthZ** = *what may you do?* Confusing them is the root of most access-control bugs.
+
+## Context
+A multi-tenant API with four roles per membership. It must scale horizontally (no sticky sessions), and a
+demotion must take effect **immediately** — you cannot wait for a token to expire before revoking power.
+
+## Decision
+- **Authentication — stateless JWT.** The token is `header.payload.signature`. On each request the server
+  **recomputes** the signature over the incoming `header.payload` using `SECRET_KEY` and compares it to the
+  signature in the token. Match → genuine and untampered. **No database is touched** for authN; the
+  `SECRET_KEY` is an *ingredient*, never a stored signature. Expiry is the `exp` claim in the payload.
+- **Authorization — RBAC, role read from the DB per request.** The role lives on the **`membership`** row,
+  not on `users` and **not in the token**. After authN yields a `user_id`, we load the membership for
+  `(user_id, organization_id)` to get the **current** role, then check a **static `ROLE_PERMISSIONS` map**
+  via a `require_permission()` dependency. Permissions attach to **roles only**, never to individual users.
+- **The four gates, in order:** authN (401) → RBAC (403) → tenancy (404) → guard (409).
+- **Refresh-token rotation** (M2) keeps access tokens short-lived so the revocation window is small.
+
+## Alternatives considered
+- **Server-side sessions.** Stateful, needs a shared session store, complicates horizontal scaling.
+  Rejected — statelessness is the point.
+- **Role baked into the JWT.** No per-request DB read, but the role goes **stale**: a demotion wouldn't take
+  effect until expiry. Rejected — the one indexed membership lookup buys immediate revocation.
+- **Per-user permission grants / DB-driven custom roles.** Rejected: four fixed clinical roles; a static,
+  version-controlled, PR-reviewable map beats a role-builder nobody asked for (YAGNI). Per-user exceptions
+  are how RBAC rots.
+- **Third-party IdP (Auth0/Cognito).** Reasonable in production, but hides the fundamentals this project
+  exists to demonstrate. Rejected for the portfolio build.
+
+## Consequences
+**Good:** stateless → scales horizontally; immediate revocation via the DB role read; authZ is one static
+map, reviewable in a PR; the scope check (tenancy) is deliberately *not* in the permission string, so a
+static string can never authorise a cross-tenant row.
+**Bad:** a valid JWT can't be revoked *before* expiry (mitigate: short expiry + refresh rotation); one
+indexed membership query per request (cheap, and it's what enables revocation).
+
+## Revisit when
+We need SSO / external identity, or org-configurable roles become a real customer requirement (then design
+custom roles + audit them brutally — see `permissions.md` §8).

--- a/docs/adr/ADR-004-feature-flags.md
+++ b/docs/adr/ADR-004-feature-flags.md
@@ -1,0 +1,33 @@
+# ADR-004 — Build a small DB-backed feature-flag service (not buy)
+
+**Status:** Accepted · M1
+
+## Context
+We need per-tenant control over features, and — the genuinely important use — to roll out a **new AI prompt/
+model version to a small percentage of orgs** and compare it in Langfuse **before** a full rollout. Flags
+tie the platform story to the AI story.
+
+## Decision
+Build a small **DB-backed** flag service: `evaluate(flag, org, user)` resolves in order **global default →
+org override → user override → percentage rollout** (a **stable hash** of the user id, so the same user
+stays consistently in-or-out of a rollout). An admin UI toggles them. First flags: `ai_triage`,
+`ai_summaries`, `chat_assistant`, `lab_trends`, and a versioned `ai_prompt_v2` gate.
+
+## Alternatives considered
+- **Managed SaaS (LaunchDarkly) / OSS (Unleash, Flagsmith).** More features (targeting, dashboards) than we
+  need, plus a dependency and (for SaaS) cost and another data processor to justify under DSGVO. Rejected —
+  our needs are small and specific.
+- **Environment-variable flags.** Can't do per-tenant or percentage rollout, and flipping one needs a
+  redeploy. Rejected — the per-tenant % rollout is the whole point.
+- **No flags.** Rejected — then there's no safe way to trial a new AI prompt on a subset and compare.
+
+## Consequences
+**Good:** full control; per-tenant + percentage rollout tied directly to a Langfuse comparison; a real,
+non-trivial platform capability we can demo and explain; no external dependency.
+**Bad:** we maintain it (evaluation, caching, the admin UI); it will lack the advanced targeting a mature
+product has. Acceptable — **build-vs-buy tilts to build only because the scope is small and the learning +
+the AI-rollout use justify it.**
+
+## Revisit when
+Flag logic grows complex (audiences, scheduling, dependencies) or the team grows — at which point a mature
+tool earns its cost and we migrate.

--- a/docs/adr/ADR-005-file-storage.md
+++ b/docs/adr/ADR-005-file-storage.md
@@ -1,0 +1,39 @@
+# ADR-005 — Object storage for PDFs + API-minted short-lived presigned URLs
+
+**Status:** Accepted · M1 · *(resolves the ENG-14 sanity-pass finding B)*
+
+## Context
+Documents are PDFs — binary blobs, some large. They must **not** live in Postgres (bloats the DB, slows
+backups, wrong tool). And they are **medical data**: every access must be authorised through the four gates
+and **logged in `audit_log`**. So the real question is not just *where the bytes live* but *how the browser
+is allowed to fetch them*.
+
+## Decision
+- **Object storage** (Cloudflare **R2** in prod, **MinIO** in dev — both speak the **S3 API**). The DB
+  stores only a **`storage_key`**; the bytes live in the bucket. The bucket is **private** — never public.
+- **Access via API-minted, short-lived presigned URLs.** The browser asks the API for a document; the API
+  runs the four gates, **writes the `audit_log` read event**, then returns a **presigned URL scoped to that
+  one object with a short TTL** (minutes). The browser fetches the bytes directly from storage using it.
+- **This is the caveat to "the frontend talks only to the API"** (`architecture.md`): the browser *does*
+  fetch bytes from storage — but only via a capability the **API authorised and minted**. The API stays the
+  single authority; it just doesn't proxy the bytes.
+
+## Alternatives considered
+- **PDFs in Postgres (`bytea`).** Rejected — DB bloat, slow backups, memory pressure.
+- **API proxies every byte** (stream through the app). Safe and simple, keeps the "only talks to the API"
+  claim literally true, but the app carries all transfer load. Reasonable fallback; rejected as default for
+  scalability.
+- **Public bucket / permanent public URLs.** Rejected outright — unauthenticated access to patient data.
+- **Long-lived presigned URLs.** Rejected — a leaked URL is a long-lived bearer capability. Short TTL keeps
+  the exposure small.
+
+## Consequences
+**Good:** the app never streams large blobs (scales); the API keeps authority and audits every read; dev/prod
+parity via the S3 API.
+**Bad:** a presigned URL is, for its TTL, a **bearer capability** — anyone holding it can fetch that one
+object until it expires (mitigate: short TTL, per-object scope, and log the mint). Slightly more moving parts
+than proxying.
+
+## Revisit when
+Compliance demands that no bytes ever leave via a client-fetchable URL — then switch the default to
+API-proxied streaming (the fallback above).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records (ADRs)
+
+An **ADR** captures *one* significant decision: the context that forced it, what we chose, what we
+rejected, and what it costs us. It exists so a future engineer (or interviewer, or future-you) can see
+**why**, not just **what** — and so a decision is made **once**, on purpose, instead of drifting.
+
+**Template** (every ADR below follows it):
+
+> **Status** · **Context** (the forces) → **Decision** (what we chose) → **Alternatives considered**
+> (and why not) → **Consequences** (good *and* bad) → **Revisit when** (the trigger that reopens it).
+
+| ADR | Decision | Status |
+|---|---|---|
+| [ADR-001](./ADR-001-monolith.md) | Modular **monolith** over microservices | Accepted |
+| [ADR-002](./ADR-002-multi-tenancy.md) | **Shared DB, `organization_id` on every row** (RLS as the strong form) | Accepted |
+| [ADR-003](./ADR-003-auth.md) | **Stateless JWT** (authN) + **RBAC read from the DB** (authz) | Accepted |
+| [ADR-004](./ADR-004-feature-flags.md) | **Build** a small DB-backed flag service, not buy | Accepted |
+| [ADR-005](./ADR-005-file-storage.md) | **Object storage** + API-minted **short-lived presigned URLs** | Accepted |
+
+> An ADR is **immutable once accepted.** If a decision changes, you write a *new* ADR that supersedes the
+> old one — you don't edit history. That's the whole point of a *record*.


### PR DESCRIPTION
Closes ENG-16.

Five ADRs in `docs/adr/`, each following Context → Decision → Alternatives → Consequences → Revisit-when, plus an index (`README.md`).

| ADR | Decision |
|---|---|
| 001 | Modular **monolith** over microservices (argues why NOT microservices) |
| 002 | **Shared DB, `organization_id` on every row** + RLS as the strong form; uuid PKs |
| 003 | **Stateless JWT** (authN) + **RBAC read from the DB** (authz), four gates — resolves sanity-pass **finding A** |
| 004 | **Build** a small DB-backed feature-flag service (global→org→user→% rollout), not buy |
| 005 | **Object storage** + API-minted **short-lived presigned URLs** — resolves sanity-pass **finding B** |

Findings **C** (observability on the C4 diagrams) and **D** (Next.js "runs in browser" label) are `architecture.md` diagram fixes — left as a small follow-up, still tracked in the ENG-16 comment thread.

**Squash-merge title to use:** `docs(adr): ADR-001..005 — architecture decision records (ENG-16)`